### PR TITLE
Updated Configs 1-27-2019

### DIFF
--- a/Better PSAC Config/Data/EventListView.txt
+++ b/Better PSAC Config/Data/EventListView.txt
@@ -200,6 +200,7 @@ C
 
 08000100
 V
+00000000-Can pass through solid stage elements
 00000001-Can drop off side of stage
 00000002-Can't drop off side of stage
 00000005-In Air; Can leave stage vertically

--- a/Better PSAC Config/Data/Events.txt
+++ b/Better PSAC Config/Data/Events.txt
@@ -194,7 +194,7 @@ Links a Status ID with an interrupt, which will only allow the interrupt to exec
 006501
 
 02060100
-Enable Status ID
+Enable Action Status ID
 Enables the given Status ID.
 
 

--- a/Better PSAC Config/Data/Events.txt
+++ b/Better PSAC Config/Data/Events.txt
@@ -24,8 +24,8 @@ Execute the the previously set loop.
 
 
 00060000
-Loop Break?
-Breaks out of the current loop?
+Loop Break
+Breaks out of the current loop
 
 
 00070100
@@ -40,72 +40,72 @@ Return from a Subroutine.
 
 00090100
 Goto
-Goto the event location specified and execute.
+Goto the event location specified and execute (does not return afterwards).
 2
 
 000A0100
-If
-Start an If block until an Else or an EndIf is reached.
+If: Requirement
+Start an If block until an Else or an End If is reached. Use this If to check for a requirement.
 6
 
 000A0200
-If
-Start an If block until an Else or an EndIf is reached.
+If: Requirement Value
+Start an If block until an Else or an End If is reached. Use this If to check for a requirement with a specified value.
 65
 
 000A0400
-If
-Start an If block until an Else or an EndIf is reached.
+If: Comparison
+Start an If block until an Else or an End If is reached. Use this If to compare values.
 6505
 
 000B0100
-And
-Seems to be an "and" to an If statement.
+And: Requirement
+Insert an And statement to an If statement. Use this And to check for a requirement.
 6
 
 000B0200
-And
-Seems to be an "and" to an If statement.
+And: Requirement Value
+Insert an And statement to an If statement. Use this And to check for a requirement with a specified value.
 65
 
 000B0400
-And Comparison
-Seems to be an "And" to an If statement.
+And: Comparison
+Insert an And statement to an If statement. Use this And to compare values.
 6505
 
 000C0100
-Or
-Insert an alternate requirement to fall back on if the above requirement(s) are not met.
+Or: Requirement
+Insert an Or statement to an If statement. Use this And to check for a requirement.
 6
 
 000C0200
-Or
-Insert an alternate requirement to fall back on if the above requirement(s) are not met.
+Or: Requirement Value
+Insert an Or statement to an If statement. Use this Or to check for a requirement with a specified value.
 65
 
 000C0400
-Or Comparison
-Insert an alternate requirement to fall back on if the above requirement(s) are not met.
+Or: Comparison
+Insert an Or statement to an If statement. Use this Or to compare values.
 6505
 
 000D0100
-Else If
-Insert an Else If block inside of an If block.
+Else If: Requirement
+Insert an Else If block to go with an If series. Use this Else If to check for a requirement.
 6
 
 000D0200
-Else If
-Insert an Else If block inside of an If block.
+Else If: Value
+Insert an Else If block to go with an If series. Use this Else If to check for a requirement with a specified value.
 65
 
 000D0400
-Else If Comparison
-Insert an Else If block inside of an If block.
+Else If: Comparison
+Insert an Else If block to go with an If series. Use this Else if to compare values.
 6505
 
 000E0000
 Else
-Insert an Else block inside an If block.
+Insert an Else block to go with an If series.
 
 
 000F0000
@@ -120,12 +120,12 @@ Begin a multiple case Switch block.
 
 00110100
 Case
-Handler for if the variable in the switch statement equals the specified value.
+Handler for if the variable in the switch block equals the specified value.
 
 
 00120000
 Default Case
-The case chosen if none of the others are executed.
+The case chosen if none of the others are executed in a switch block.
 
 
 00130000
@@ -140,61 +140,61 @@ Appears within Case statements; exits the switch event completely. All code loca
 
 01010000
 Loop Rest
-Stop subsequent loads until the "Set Loop Resume Requirement" is achieved.
+Stops a loop from iterating again until the "Set Loop Resume Requirement" is achieved.
 
 
 02000300
-Change Action Status
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action Status: Requirement
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a requirement being met.
 006
 
 02010200
-Change Action
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action: Requirement
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action is based on a requirement being met.
 06
 
 02010300
-Change Action
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action: Requirement Value
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action is based on a requirement with a specified value being met.
 065
 
 02010500
-Change Action
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action: Comparison
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action is based on a comparison.
 06505
 
 02040100
-Additional Action Requirement
-Add an additional requirement to the preceeding Change Action statement.
+Additional Action Requirement: Requirement
+Add an additional requirement to the preceeding Change Action statement. This Additional Action Requirement is based on a requirement being met.
 6
 
 02040200
-Additional Action Requirement
-Add an additional requirement to the preceeding Change Action statement.
+Additional Action Requirement: Requirement Value
+Add an additional requirement to the preceeding Change Action statement. This Additional Action Requirement is based on a requirement with a specified value being met.
 65
 
 02040400
-Additional Action Requirement
-Add an additional requirement to the preceeding Change Action statement.
+Additional Action Requirement: Comparison
+Add an additional requirement to the preceeding Change Action statement. This Additional Action Requirement is based on a comparison.
 6505
 
 02050300
-Set Status ID Interrupt
-Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID when the Requirement is met (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
+Set Status ID Interrupt: Requirement
+Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID. This Set Status ID Interrupt is based on a requirement being met. (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
 006
 
 02050400
-Set Status ID Interrupt
-Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID when the Requirement is met (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
+Set Status ID Interrupt: Requirement Value
+Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID. This Set Status ID Interrupt is based on a requirement with a specified value being met. (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
 0065
 
 02050600
-Set Status ID Interrupt
-Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID when the Requirement is met (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
+Set Status ID Interrupt: Comparison
+Links a Status ID with an interrupt, which will only allow the interrupt to execute (or prevent) the Status ID. This Set Status ID Interrupt is based on a comparison. (Warning: Persists globally and can cause memory leaks. Recommended for the on-load routine.)
 006501
 
 02060100
-Disable Other Status ID
+Enable Status ID
 Enables the given Status ID.
 
 
@@ -204,7 +204,7 @@ Change the current sub action.
 
 
 04000200
-Change Sub Action
+Change Sub Action: Pass Frame
 Change the current sub action. Can specify whether or not to pass the current frame or start the animation over.
 03
 
@@ -265,11 +265,11 @@ Generate an offensive collision bubble - is able to achieve unique effects. Help
 
 06170300
 Defensive Collision
-Generate a defensive collision bubble that nullifies close combat attacks.
+Generate a defensive collision bubble that nullifies close combat attacks. Read more about how this works here: https://tinyurl.com/defensive-collisions
 
 
 06180300
-Defensive Collision Operation
+Defensive Collision: Remove
 Removes defensive collisions.
 
 
@@ -330,12 +330,12 @@ Stops the specified sound effect immediately.
 
 0A070100
 Sound Effect 07
-Play a specified sound effect. sound effect occurs when landing.(Exception: Mario's Fireball)
+Play a specified sound effect. sound effect occurs when landing. (Exception: Mario's Fireball)
  
 
 0C050000
 Terminate Instance
-Causes the acting instance to terminate (if possible). Will load secondary instance if available (i.e. character transformation).
+If used within an article, causes the acting article instance to terminate (if possible). Has other niche uses as well, such as loading secondary instance if available (i.e. character transformation).
 
 
 0C0B0000
@@ -365,12 +365,12 @@ Dictates the frame speed of the sub action. Example: Setting to 2 makes the anim
 
 0C230200
 Time Manipulation
-Change the speed of time for various parts of the environment.Scalar=time stop, value=slow time. If you use a Scalar in parameter 0, then use parameter 1 to a value set how long time stops. if you use a value in parameter 0, use parameter 1 to set a value how long time slows. using a scalar in parameter 0 and 1 will stop time forever.
+Change the speed of time for various parts of the environment. Scalar=time stop, Value=slow time. If you use a Scalar in parameter 0, then use parameter 1 to a value set how long time stops. if you use a value in parameter 0, use parameter 1 to set a value how long time slows. Using a scalar in parameter 0 and 1 will stop time forever.
 
 
 0E000100
 Set Air/Ground
-Sets the current physics state.
+Sets the current physics state of your character.
 
 
 08000100
@@ -380,13 +380,13 @@ Determines whether or not the character will slide off the edge.
 
 10000100
 Generate Article
-Generate a pre-made prop effect from the prop library.
+Generates a character specific article: a pre-made prop effect from the prop library.
 
 
 10000200
-Generate Article
-Generate a pre-made prop effect from the prop library.
-
+Generate Article: Subaction Exclusive
+Generates a character specific article: a pre-made prop effect from the prop library. Has option to force article to terminate after subaction ends.
+03
 
 10010100
 Article Event 02
@@ -545,8 +545,8 @@ Subtract a specified value from a basic variable.
 
 12050300
 Basic Variable Random
-Load a basic variable with a random integer.
-115
+Load a basic variable with a random integer between a min and max value.
+005
 
 120D0200
 Basic Variable Multiply
@@ -560,12 +560,12 @@ Divide a basic value by the specified value.
 
 12030100
 Basic Variable Increment
-Variable++
+Variable++ (adds 1)
 5
 
 12040100
 Basic Variable Decrement
-Variable--
+Variable-- (subtracts 1)
 5
 
 12110200
@@ -590,7 +590,7 @@ Subtract a specified value from a float variable.
 
 12090300
 Float Variable Random
-Load a float variable with a random integer.
+Load a float variable with a random integer between a min and max value.
 115
 
 120F0200
@@ -679,7 +679,7 @@ Cause the character to throw the currently held item.
 11555
 
 1F090100
-Item Visibility
+Item Visibility: Held Items
 Determines visibilty of the currently held item.
 3
 
@@ -755,7 +755,7 @@ Adds or subtracts speed to the char's current momentum.
 
 0E060100
 Disallow Certain Movements
-When set to 2, sideways movement is disallowed. When set to 1, disables vertical gravity. Note: Hitstun can often times enhance momentum in the disabled direction.
+When set to 1, disables vertical gravity. When set to 2, sideways movement is disallowed. Note: Hitstun can often times enhance momentum in the disabled direction.
 
 
 0E070100
@@ -775,7 +775,7 @@ When set to 1, horizontal speed and decay rate are reset back to 0.
 
 0C250100
 Tag Display
-Disables or enables tag display for the current sub action.
+Disables or enables tag display for the current sub action. The tag is the icon above your player (e.g. the P1 icon that shows up over your player's head during a match).
 3
 
 1E000200
@@ -800,12 +800,12 @@ Deletes a hitbox of the specified ID. Only guaranteed to work on Offensive Colli
 
 0B000200
 Model Changer
-Changes the character's model in certain preset ways defined in the Misc section. (Examples: sheathe sword, retreat into shell, etc.)
+Changes the character's model in certain preset ways defined in the Misc section. (Examples: sheathe sword, retreat into shell, etc). Will revert back after action ends.
 
 
 0B010200
-Model Display Toggle?
-Changes what entries of Hidden and Visible bone indexes from Model Display are used in some fashion.
+Model Changer: Permanent
+Changes the character's model in certain preset ways defined in the Misc section. (Examples: sheathe sword, retreat into shell, etc). Will persist even after action ends.
 
 
 14040100
@@ -820,7 +820,7 @@ Creates a rumble loop on the controller.
 
 18000100
 Slope Contour Stand
-Moves specific parts of the character if on sloped ground?
+Keeps feet properly on ground when using move on slope. 0: No feet are on the ground. 2: Left foot is on the ground. 4: Right foot if on the ground. 6: Both feet are on the ground.
 
 
 18010200
@@ -839,13 +839,13 @@ Undefined. in used Go to Loop.
 
 
 02000400
-Change Action Status
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action Status: Requirement Value
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a requirement with a specified value being met.
 0065
 
 02000600
-Change Action Status
-Change the current action upon the specified requirement being met. (the requirement does not have to be met at the time this ID is executed - it can be used anytime after execution.)
+Change Action Status: Comparison
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a comparison.
 006505
 
 02080100
@@ -874,43 +874,43 @@ Possibly unregisters a previously created interrupt.
 
 
 04020100
-Set Loop Resume Requirement
-Set requirement for reading "Loop Rest" or later.
+Set Loop Resume Condition: Requirement
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement.
 6
 
 04020200
-Set Loop Resume Requirement
-Set requirement for reading "Loop Rest" or later.
+Set Loop Resume Condition: Requirement Value
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement with a specified value being met.
 65
 
 04020400
-Set Loop Resume Requirement
-Set requirement for reading "Loop Rest" or later.
+Set Loop Resume Condition: Comparison
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a comparison.
 6505
 
 04030100
-Additional Loop Resume Requirement
-Add an additional requirement to Set Loop Resume Requirement.
+Additional Loop Resume Condition: Requirement
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement.
 6
 
 04030200
-Additional Loop Resume Requirement
-Add an additional requirement to Set Loop Resume Requirement.
+Additional Loop Resume Condition: Requirement Value
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement with a specified value being met.
 65
 
 04030400
-Additional Loop Resume Requirement
-Add an additional requirement to Set Loop Resume Requirement.
+Additional Loop Resume Condition: Comparison
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a comparison.
 6505
 
 04050100
-Additional Loop Resume Requirement
+Additional Loop Resume Condition: Unknown
 Used quite a bit in Meta Knight's special move actions, as well as Pit's Down-B.
 
 
 04060100
 Set Animation Frame
-Changes the current frame of the animation. Does not change the frame of the sub action (i.e. timers and such are unaffected).
+Changes the current frame of the animation. Does not change the frame of the sub action (i.e. timers and such are unaffected). Works when used in articles that have assigned animations in the FitEtc file.
 1
 
 04010200
@@ -1075,7 +1075,7 @@ Undefined.
 
 0C060000
 Enter Final Smash State
-Allows use of Final Smash locked articles, variables, etc. Highly unstable.
+Allows use of Final Smash locked articles, variables, etc. Highly unstable. When used in certain articles (such as Mario's fireball), it loads in a value from article floating point parameter table and applies it (Mario's fireball loads in velocity bounce multiplier, for example).
 
 
 0C070000
@@ -1085,7 +1085,7 @@ Undefined.
 
 0C080000
 Terminate Self
-Used by certain article instances to remove themselves.
+Used by certain article instances to remove themselves instead of terminate instance (note: nearly all projectiles in the game will terminate fine with the terminate instance command).
 
 
 0C090100
@@ -1190,12 +1190,12 @@ Undefined.
 
 0D000200
 Concurrent Infinite Loop
-Runs a subroutine once per frame for the current action.
+Runs a subroutine once per frame for the current action in parallel. This means that this subroutine loop will run independently of the code that comes after it in the action.
 02
 
 0D010100
 Terminate Concurrent Infinite Loop
-Seems to stop the execution of a loop created with 0D000200 (Concurrent Infinite Loop).
+Terminates a concurrent infinite loop.
 
 
 0F030200
@@ -1249,7 +1249,7 @@ Undefined.
 
 
 1F0A0000
-Obliterate Held Item
+Delete Held Item
 Deletes the item that the character is holding.
 
 
@@ -1289,8 +1289,8 @@ Undefined. Used in Samus.
 
 
 1F0F0100
-Morph Model Event
-If false model will appear else if true model will disappear.
+Item Visibility: Wearable Items
+Visiblity of wearable items (bunny hood, franklin badge, screw attack, etc)
 
 
 01000000
@@ -1310,7 +1310,7 @@ Appears to control posture graphics.
 
 11150300
 Terminate Graphic Effect
-Terminate a lingering graphical effect.
+Terminate a lingering graphical effect. First parameter is the graphic effect id. The other two parameters just set to true.
 033
 
 18010300

--- a/Better PSAC Config/Data/Events.txt
+++ b/Better PSAC Config/Data/Events.txt
@@ -148,6 +148,16 @@ Change Action Status: Requirement
 Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a requirement being met.
 006
 
+02000400
+Change Action Status: Requirement Value
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a requirement with a specified value being met.
+0065
+
+02000600
+Change Action Status: Comparison
+Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a comparison.
+006505
+
 02010200
 Change Action: Requirement
 Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action is based on a requirement being met.
@@ -198,6 +208,30 @@ Enable Action Status ID
 Enables the given Status ID.
 
 
+02080100
+Disable Action Status ID
+Disables the Action associated with the given Status ID.
+
+
+02090200
+Invert Action Status ID
+Appears to invert (or possibly only disable) a specific Status ID's enabled/disabled status. For example, if a character can crawl, this is used to disable the ability to dash when crouched, even though naturally crouching allows dashing through 020A (Allow Specific Interrupt).
+
+
+020A0100
+Allow Specific Interrupt
+Allows interruption only by specific commands. See parameters for list of possible interrupts.
+
+
+020B0100
+Prevent Specific Interrupt
+Closes the specific interruption window. Must be set to the same thing as the allow specific interrupt that you wish to cancel.
+
+
+020C0100
+Clear Prevent Interrupt
+Possibly unregisters a previously created interrupt.
+
 04000100
 Change Sub Action
 Change the current sub action.
@@ -207,6 +241,46 @@ Change the current sub action.
 Change Sub Action: Pass Frame
 Change the current sub action. Can specify whether or not to pass the current frame or start the animation over.
 03
+
+04020100
+Set Loop Resume Condition: Requirement
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement.
+6
+
+04020200
+Set Loop Resume Condition: Requirement Value
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement with a specified value being met.
+65
+
+04020400
+Set Loop Resume Condition: Comparison
+Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a comparison.
+6505
+
+04030100
+Additional Loop Resume Condition: Requirement
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement.
+6
+
+04030200
+Additional Loop Resume Condition: Requirement Value
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement with a specified value being met.
+65
+
+04030400
+Additional Loop Resume Condition: Comparison
+Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a comparison.
+6505
+
+04050100
+Additional Loop Resume Condition: Unknown
+Used quite a bit in Meta Knight's special move actions, as well as Pit's Down-B.
+
+
+04060100
+Set Animation Frame
+Changes the current frame of the animation. Does not change the frame of the sub action (i.e. timers and such are unaffected). Works when used in articles that have assigned animations in the FitEtc file.
+1
 
 05000000
 Reverse Direction
@@ -837,81 +911,6 @@ Moves entire character to match sloped ground?
 Flow 03
 Undefined. in used Go to Loop.
 
-
-02000400
-Change Action Status: Requirement Value
-Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a requirement with a specified value being met.
-0065
-
-02000600
-Change Action Status: Comparison
-Change the current action upon the specified requirement being met. The requirement does not have to be met at the time this ID is executed - it can be used anytime after execution. This Change Action Status is based on a comparison.
-006505
-
-02080100
-Disable Action Status ID
-Disables the Action associated with the given Status ID.
-
-
-02090200
-Invert Action Status ID
-Appears to invert (or possibly only disable) a specific Status ID's enabled/disabled status. For example, if a character can crawl, this is used to disable the ability to dash when crouched, even though naturally crouching allows dashing through 020A (Allow Specific Interrupt).
-
-
-020A0100
-Allow Specific Interrupt
-Allows interruption only by specific commands. See parameters for list of possible interrupts.
-
-
-020B0100
-Prevent Specific Interrupt
-Closes the specific interruption window. Must be set to the same thing as the allow specific interrupt that you wish to cancel.
-
-
-020C0100
-Clear Prevent Interrupt
-Possibly unregisters a previously created interrupt.
-
-
-04020100
-Set Loop Resume Condition: Requirement
-Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement.
-6
-
-04020200
-Set Loop Resume Condition: Requirement Value
-Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a requirement with a specified value being met.
-65
-
-04020400
-Set Loop Resume Condition: Comparison
-Sets the condition that needs to be met in order for a loop to iterate again after a Loop Rest has been hit (must be used before Loop Rest command). This Set Loop Resume is based on a comparison.
-6505
-
-04030100
-Additional Loop Resume Condition: Requirement
-Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement.
-6
-
-04030200
-Additional Loop Resume Condition: Requirement Value
-Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a requirement with a specified value being met.
-65
-
-04030400
-Additional Loop Resume Condition: Comparison
-Add an additional requirement to Set Loop Resume Condition. This Additional Set Loop Resume is based on a comparison.
-6505
-
-04050100
-Additional Loop Resume Condition: Unknown
-Used quite a bit in Meta Knight's special move actions, as well as Pit's Down-B.
-
-
-04060100
-Set Animation Frame
-Changes the current frame of the animation. Does not change the frame of the sub action (i.e. timers and such are unaffected). Works when used in articles that have assigned animations in the FitEtc file.
-1
 
 04010200
 Set Loop Resume Requirement 01

--- a/Better PSAC Config/Data/Events.txt
+++ b/Better PSAC Config/Data/Events.txt
@@ -1337,6 +1337,11 @@ Terminate Independent Subroutine (Custom)
 Stops a running independent subroutine. (Requires the relevant code by Mawootad.)
 2
 
+05060300
+Rotate Character Model
+Rotates character's model by amount specified
+111
+
 12200200
 Attribute Range Set (Custom)
 Requires the On the Fly Attribute Modification code by Mawootad.

--- a/Better PSAC Config/Data/Events.txt
+++ b/Better PSAC Config/Data/Events.txt
@@ -732,6 +732,16 @@ Item Property
 Modify a property of the currently held item.
 01
 
+1F050000
+Fire Weapon
+Fires a shot from the currently held item. (May have other unknown applications)
+
+
+1F060100
+Fire Projectile
+Fires a projectile of the specified degree of power.
+
+
 1F070100
 Rocket Operation
 Undefined: Is used when firing a cracker launcher.
@@ -740,6 +750,16 @@ Undefined: Is used when firing a cracker launcher.
 1F080100
 Generate Item
 Generate an item in the character's hand.
+
+
+1F090100
+Item Visibility: Held Items
+Determines visibilty of the currently held item.
+3
+
+1F0A0000
+Delete Held Item
+Deletes the item that the character is holding.
 
 
 1F0C0100
@@ -752,19 +772,9 @@ Throw Item
 Cause the character to throw the currently held item.
 11555
 
-1F090100
-Item Visibility: Held Items
-Determines visibilty of the currently held item.
-3
-
-1F050000
-Fire Weapon
-Fires a shot from the currently held item. (May have other unknown applications)
-
-
-1F060100
-Fire Projectile
-Fires a projectile of the specified degree of power.
+1F0F0100
+Item Visibility: Wearable Items
+Visiblity of wearable items (bunny hood, franklin badge, screw attack, etc)
 
 
 21000000
@@ -1247,11 +1257,6 @@ Camera 0C
 Undefined.
 
 
-1F0A0000
-Delete Held Item
-Deletes the item that the character is holding.
-
-
 20000200
 Turn 00
 unknown.
@@ -1285,11 +1290,6 @@ Undefined.
 18030200
 Character Specific 03
 Undefined. Used in Samus.
-
-
-1F0F0100
-Item Visibility: Wearable Items
-Visiblity of wearable items (bunny hood, franklin badge, screw attack, etc)
 
 
 01000000

--- a/Better PSAC Config/Data/Parameters.txt
+++ b/Better PSAC Config/Data/Parameters.txt
@@ -574,7 +574,7 @@ Unknown, Usually 39.
 
 08000100
 Character State
-1: Can drop off side of stage.  2: Can't drop off side of stage.  5: Treated as in air; can leave stage vertically.  Other states unknown.
+0: Can pass through solid stage elements. 1: Can drop off side of stage.  2: Can't drop off side of stage.  5: Treated as in air; can leave stage vertically.  Other states unknown.
 
 08020100
 Character State?
@@ -928,9 +928,9 @@ The time it takes for the sword glow to fade out.
 Graphic
 The file from which to call from/The graphical effect to call, where XXXXYYYY is X=File# Y=Graphic ID.
 Boolean
-No Description Available.
+Set this to True.
 Boolean
-No Description Available.
+Set this to True.
 
 11170600
 Undefined
@@ -1078,9 +1078,9 @@ The variable to decrement.
 
 12050300
 Value
-The minimum random value to load.
+The minimum random value to load (inclusive).
 Value
-The maximum random value to load.
+The maximum random value to load (inclusive).
 Variable
 The Basic type variable to access.
 
@@ -1180,6 +1180,10 @@ Scalar,unknown.
 Parameter 9
 Hex ID.
 
+18000100
+Grounded Feet
+States which of the player's feet are currently touching the ground. 0: No feet are on the ground. 2: Left foot is on the ground. 4: Right foot is on the ground. 6: Both feet are on the ground.
+
 1A000100
 Size
 The size of the screenshake.
@@ -1254,7 +1258,7 @@ Usually an internal constant basic variable set at 1031.
 
 1F0F0100
 True or False
-If set to false, model will appear, else disapper.
+Visiblity of wearable items (bunny hood, franklin badge, screw attack, etc)
 
 21010400
 Red

--- a/Better PSAC Config/Data/Parameters.txt
+++ b/Better PSAC Config/Data/Parameters.txt
@@ -1324,6 +1324,14 @@ Location of the subroutine code to be ran.
 Thread ID
 ID of the thread to be terminated.
 
+05060300
+X
+Amount to rotate model on X Axis
+Y
+Amount to rotate model on Y Axis
+Z
+Amount to rotate model on Z Axis
+
 12200200
 Value
 The value to set the variable(s) to.


### PR DESCRIPTION
Started by editing a few things...and then sort of did a scan through everything and made a bunch of changes to make things more clear. Please look these over and decide if you agree with the changes or not!!! I checked out everything in PSA Compressor and it doesn't look like I made any config typos that would throw off alignment or anything like that, but always good to have another pair of eyes look at it.

Also -- I don't know if there were any PSA Compressor Configs released in between the time of the last commit to this repo and now, as it is hard to look at all channels when they aren't Pinned...if I missed anything obvious that someone else updated somewhere in the depths of a channel please let me know and I'll make sure to add it.

**Set Aerial/Onstage State 08000100**
- Discord User Bent00 found that Character State 0 allows character to pass through solid elements
- Descriptions updated where applicable

**Loop Break 00060000**
- Removed the question marks from the command name and description...since it's definitely been confirmed that this is a loop break after all these years

**Basic Variable Random 12050300**
- Defaulted the range parameters from scalars to values
- Updated description for min and max parameters to make a note that they are both inclusive

**Item Visibility: Wearable Items 1F0F0100**
- Found this command, originally named "Morph Model Event", actually hides or shows wearable items (such as bunny hood and franklin badge). Found this in Kirby's final smash coding.
- Command was renamed and description updated
- Also as a result, the other command for Item Visibility for held items (**Item Visibility 1F090100**) has been renamed to **Item Visibility: Held Items** just to make things more clear)

**Goto 00090100**
- Updated description to specify that it does not return afterwards

**All If Related Statements**
- Updated all of them to have of three title suffixes: Requirement, Requirement Value, and Comparison
- This will make it easier to differentiate between the three of each grouping when looking at the command list
- Example: If: Requirement | If: Requirement Value | If: Comparison
- Same thing was done to any other commands that followed this pattern, such as the **Change Action** commands.
- The **Set Loop Resume Requirement** commands have been renamed to **Set Loop Resume Condition** and then with the added suffixes to make things more clear. Updated their descriptions as well to make it clear that these are needed to resume a loop after a Loop Rest.
- All descriptions have been updated.

**Switch Related Statements**
- Very minor description updates to make things more clear.

**Loop Rest 01010000**
- Updated description to make it more clear since nobody seems to understand what this does and then wonder why their loops only loop one time.

**Enable Action Status ID 02060100**
- Okay this is the only one I'm 75% on...originally the command was called **Disable Other Status Id** but the description said that it _enables_ the status id...and there is another command listed as **Disable Action Status Id *...so I THINK this is supposed to be **Enable Status ID 02080100** (and this makes sense when looking at specials that use both disable and enable status id commands).

**Change Subaction: Pass Frame 04000200**
- Changed command name from **Change Subaction** to **Change Subaction: Pass Frame** to differentiate it from the other **Change Subaction 04000100** command.

**Defensive Collision Related Commands**
- **Defensive Collision 06170300** - updated description to include a link to a Google Doc I made of KJP's Discord explanation on how to set up a Defensive Collision for any character
**Defensive Collision: Remove 06180300** - changed command name from **Defensive Collision Operation** to **Defensive Collision: Remove** to match the description and make things more clear.

**Terminate Instance 0C050000**
- Updated description to make it more clear what it does when used in articles

**Generate Article: Subaction Exclusive 10000200**
- Updated command name from **Generate Article** to **Generate Article: Subaction Exclusive** to match the parameter and differentiate it from the other **Generate Article 10000100** command
- Updated descriptions on both **Generate Article** commands to make things more clear.

**Slope Contour Stand 18000100**
- Updated param name and descriptions based on KJP's Discord post so people actually know how this works

**Terminate Self 0C080000**
- Minor update to the description to make mention that the **Terminate Instance** command is what should be used instead if wanting to terminate a projectile article.

**Concurrent Infinite Loop Related Commands**
- Updated descriptions to make things more clear.

**Delete Held Item 1F0A0000**
- Changed command name from **Obliterate Held Item** to **Delete Held Item** to make it more clear what it is doing (while "obliterate" is a very colorful word, it's just easier to use delete

**Terminate Graphic Effect 11150300**
- Changed descriptions of the second and third parameters -- nobody seems to know what these booleans are for, but from personal experience as well as searching Discord everyone seems to be in agreement that setting both to True will handle terminating any graphic you need, so I added that to the description so people will be less confused on how to use this command.

**Rotate Character Model 05060300**
- Discovered by MarioDox, added this command to the config, added description, and labeled parameters with descriptions.

**Enter Final Smash State 0C060000**
- Updated description to add what it does when used inside of an article

**Command reorders**
- Reordered some commands in the command list so they would be closer to related commands (such as the **Change Action Status** commands and **Item** related commands)
