### PR TITLE
FighterExtract Can Take ARAM Dump for Mem2 Support

### DIFF
--- a/PSA Conversion Tools/fighterextract.d
+++ b/PSA Conversion Tools/fighterextract.d
@@ -98,11 +98,11 @@ uint[] loadDump(string path) {
 uint readMem(uint addr, uint[] dolphinDump, uint[] mem2Dump) {
   if (addr < 0x90000000u) {
     uint index = (addr-0x80000000u)/4;
-	return dolphinDump[index];
+    return dolphinDump[index];
   }
   else {
     uint index = (addr-0x90000000u)/4;
-	return mem2Dump[index];
+    return mem2Dump[index];
   }
 }
 

--- a/PSA Conversion Tools/fighterextract.d
+++ b/PSA Conversion Tools/fighterextract.d
@@ -15,7 +15,11 @@ void main(string[] args) {
   bool[uint] processedTable;
 
   //unloads RAM dump into array of 4-byte words (converted from big endian)
-  uint[] dolphinDump = loadDump();
+  uint[] dolphinDump = loadDump("ram.raw");
+  uint[] mem2Dump;
+  if (exists("aram.raw")) {
+    mem2Dump = loadDump("aram.raw");
+  }
 
   CodePiece[] actions;
   actions.reserve(0x112*2);
@@ -54,7 +58,7 @@ void main(string[] args) {
       result = "This address is invalid.".dup;
     }
     else {
-      result = readPSA(front.location, dolphinDump);
+      result = readPSA(front.location, dolphinDump, mem2Dump);
     }
 
     static immutable re = ctRegex!`2-([89][0-9A-F]{7})`;
@@ -80,8 +84,8 @@ void main(string[] args) {
   }
 }
 
-uint[] loadDump() {
-  ubyte[] raw    = cast(ubyte[]) read("ram.raw");
+uint[] loadDump(string path) {
+  ubyte[] raw    = cast(ubyte[]) read(path);
   uint[]  result = new uint[](raw.length/4);
 
   foreach (i; 0..result.length) {
@@ -91,25 +95,31 @@ uint[] loadDump() {
   return result;
 }
 
-uint readMem(uint addr, uint[] dolphinDump) {
-  uint index = (addr-0x80000000u)/4;
-  return dolphinDump[index];
+uint readMem(uint addr, uint[] dolphinDump, uint[] mem2Dump) {
+  if (addr < 0x90000000u) {
+    uint index = (addr-0x80000000u)/4;
+	return dolphinDump[index];
+  }
+  else {
+    uint index = (addr-0x90000000u)/4;
+	return mem2Dump[index];
+  }
 }
 
-char[] readPSA(uint addr, uint[] dolphinDump) {
+char[] readPSA(uint addr, uint[] dolphinDump, uint[] mem2Dump) {
   auto app     = appender!(char[]);
   uint curAddr = addr;
 
   while (true) {
-    uint eventCode = readMem(curAddr, dolphinDump);
+    uint eventCode = readMem(curAddr, dolphinDump, mem2Dump);
     if (eventCode == 0x0 || eventCode == 0x00080000) break;
 
-    uint argAddr   = readMem(curAddr+4, dolphinDump);
+    uint argAddr   = readMem(curAddr+4, dolphinDump, mem2Dump);
 
     app.formattedWrite("E=%08X:", eventCode);
 
     foreach (a; 0..(eventCode >> 8) & 0xFF) {
-      app.formattedWrite("%d-%08X,", readMem(argAddr+a*8, dolphinDump), readMem(argAddr+a*8+4, dolphinDump));
+      app.formattedWrite("%d-%08X,", readMem(argAddr+a*8, dolphinDump, mem2Dump), readMem(argAddr+a*8+4, dolphinDump, mem2Dump));
     }
 
     curAddr += 8;


### PR DESCRIPTION
Allows the program to optionally take in a Mem2 dump in addition to the normal Mem1 dump so it can properly parse injects staged in the post-0x90000000 address range.